### PR TITLE
Add posthog telemetry

### DIFF
--- a/pyepsilla/vectordb/__init__.py
+++ b/pyepsilla/vectordb/__init__.py
@@ -4,5 +4,8 @@
 from .client import Client
 from .field import Field, FieldType
 from .sentry import init_sentry
+from .telemetry import TelemetryManager
 
 init_sentry()
+
+telemetry_manager = TelemetryManager.get_singleton()

--- a/pyepsilla/vectordb/telemetry.py
+++ b/pyepsilla/vectordb/telemetry.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+# We use PostHog to collect telemetry data for how Epsilla is used.
+# Disable it by setting environment variable "POSTHOG_DISABLE"
+
+import os, socket, platform, sys
+from typing import Optional
+
+from posthog import Posthog
+import machineid
+
+POSTHOG_API_KEY = "phc_HoDjIs8hJa1dHPB6dudGwCCk5Q8t3lUaAQDWzhq9DDS"
+POSTHOG_HOST = "https://epsilla.ph.getmentioned.ai/ingest"
+
+class TelemetryManager:
+    """TelemetryManager is a singleton that collects telemetry data and sends it to PostHog"""
+
+    singleton = None
+
+    @classmethod
+    def get_singleton(cls):
+        if cls.singleton is None:
+            cls.singleton = cls()
+        return cls.singleton
+
+    def __init__(self) -> None:
+        if "POSTHOG_DISABLE" in os.environ:
+            self.client = None
+            return
+
+        # We use a hashed ID to make sure telemetry data is anonymous
+        self.machine_id = machineid.hashed_id("epsilla")
+        
+        self.client = Posthog(
+            POSTHOG_API_KEY,
+            host=POSTHOG_HOST
+        )
+        self.client.identify(self.machine_id, properties={"version": platform.version(), "platform": "{}-{}".format(sys.platform, platform.machine())})
+
+        self.capture("pyepsilla initialized")
+
+        TelemetryManager.singleton = self
+    
+    def capture(self, event: str, properties: Optional[dict] = None):
+        """Capture an event and send it to PostHog"""
+        if self.client is not None:
+            self.client.capture(self.machine_id, event, properties=properties)
+    
+    
+    
+

--- a/pyepsilla/vectordb/telemetry.py
+++ b/pyepsilla/vectordb/telemetry.py
@@ -31,7 +31,7 @@ class TelemetryManager:
 
         # We use a hashed ID to make sure telemetry data is anonymous
         self.machine_id = machineid.hashed_id("epsilla")
-        
+
         self.client = Posthog(
             POSTHOG_API_KEY,
             host=POSTHOG_HOST
@@ -41,12 +41,8 @@ class TelemetryManager:
         self.capture("pyepsilla initialized")
 
         TelemetryManager.singleton = self
-    
+
     def capture(self, event: str, properties: Optional[dict] = None):
         """Capture an event and send it to PostHog"""
         if self.client is not None:
             self.client.capture(self.machine_id, event, properties=properties)
-    
-    
-    
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 sentry_sdk
+posthog
+py-machineid


### PR DESCRIPTION
This PR adds a simple PostHog telemetry client.

### How to test it

In an interactive python shell (e.g. Colab), run the following:

```
>>> import pyepsilla
```

On PostHog event explorer, we see the captured events.

<img width="1211" alt="Screenshot 2023-10-10 at 1 14 56 PM" src="https://github.com/epsilla-cloud/epsilla-python-client/assets/5278006/d618630b-01eb-4019-b58f-b8050c7a2d78">

```
>>> pyepsilla.vectordb.telemetry.TelemetryManager.get_singleton().capture("test event")
```

This sends a test event, and we can see it in PostHog too.

<img width="1192" alt="Screenshot 2023-10-10 at 1 16 15 PM" src="https://github.com/epsilla-cloud/epsilla-python-client/assets/5278006/ce714ace-05b2-472d-a3f7-52b4d95a8c45">


